### PR TITLE
Support functional components without an explicit cast

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -33,4 +33,6 @@ export type HigherOrderComponent<RequiredProps, ProvidedProps> =
         & $Shape<RequiredProps & DefaultProps & Props>
       >
     )
+  & (<Props>(component: React.StatelessFunctionalComponent<ProvidedProps & Props>) => React.ComponentType<RequiredProps & Props>)
   & (<Props>(component: React.ComponentType<ProvidedProps & Props>) => React.ComponentType<RequiredProps & Props>)
+  & (<Props>(component: React.ComponentType<Object>) => React.ComponentType<Object>)

--- a/tests/fixtures/ValidFunctionalComponent.js
+++ b/tests/fixtures/ValidFunctionalComponent.js
@@ -4,6 +4,6 @@ import * as React from 'react';
 type Props = {string1: string, number1: number};
 
 // This is a valid functional react component that we'll use to test our HigherOrderComponents later
-const ValidFunctionalComponent: React.StatelessFunctionalComponent<Props> = (props: Props) => <div />;
+const ValidFunctionalComponent = (props: Props) => <div />;
 
 export default ValidFunctionalComponent;


### PR DESCRIPTION
* Support functional components without an explicit cast
* Add a fallback for completely untyped components (for apps that don't have 100% flow coverage)