### PR TITLE
Remove case that was swallowing errors

### DIFF
--- a/index.js.flow
+++ b/index.js.flow
@@ -35,4 +35,3 @@ export type HigherOrderComponent<RequiredProps, ProvidedProps> =
     )
   & (<Props>(component: React.StatelessFunctionalComponent<ProvidedProps & Props>) => React.ComponentType<RequiredProps & Props>)
   & (<Props>(component: React.ComponentType<ProvidedProps & Props>) => React.ComponentType<RequiredProps & Props>)
-  & (<Props>(component: React.ComponentType<Object>) => React.ComponentType<Object>)

--- a/tests/index.js
+++ b/tests/index.js
@@ -181,4 +181,11 @@ import injectFooHocClassComponent from './fixtures/injectFooHocClassComponent';
     // $FlowExpectErrorTestFunctionalComponent
     <InjectedFooFunctionHocClassComponent foo="asdf" bar={3} baz={10} />;
   })();
+
+  (function(){
+    // Ensure components have injected props defined.
+    declare var provideString2: HigherOrderComponent<{}, {string2: string}>;
+    // $FlowExpectError
+    const ProvideString1OfValidClassComponent = provideString2(ValidClassComponent);
+  })();
 })();


### PR DESCRIPTION
The extra case I added was swallowing up errors for invalid components.

This commit removes that case and adds a test case. Its removal does not adversely affect any existing tests.